### PR TITLE
feat: add new avatar base size variant

### DIFF
--- a/src/components/ZAvatar/ZAvatar.stories.ts
+++ b/src/components/ZAvatar/ZAvatar.stories.ts
@@ -100,6 +100,11 @@ export const WithSizes = (): Component => ({
         <z-avatar
           image="https://randomuser.me/api/portraits/women/24.jpg"
           user-name="Akshay Paliwal"
+          size="base"
+        ></z-avatar>
+        <z-avatar
+          image="https://randomuser.me/api/portraits/women/24.jpg"
+          user-name="Akshay Paliwal"
           size="lg"
         ></z-avatar>
         <z-avatar
@@ -132,6 +137,11 @@ export const WithSizes = (): Component => ({
         <z-avatar
           image="https://randomuser.me/api/portraits/women/24.jpg"
           user-name="Akshay Paliwal"
+          size="base"
+        ></z-avatar>
+        <z-avatar
+          image="https://randomuser.me/api/portraits/women/24.jpg"
+          user-name="Akshay Paliwal"
           size="lg"
         ></z-avatar>
         <z-avatar
@@ -159,6 +169,10 @@ export const WithSizes = (): Component => ({
         ></z-avatar>
         <z-avatar
           user-name="Akshay Paliwal"
+          size="base"
+        ></z-avatar>
+        <z-avatar
+          user-name="Akshay Paliwal"
           size="lg"
         ></z-avatar>
         <z-avatar
@@ -182,6 +196,10 @@ export const WithSizes = (): Component => ({
         <z-avatar
           user-name="Akshay Paliwal"
           size="md"
+        ></z-avatar>
+        <z-avatar
+          user-name="Akshay Paliwal"
+          size="base"
         ></z-avatar>
         <z-avatar
           user-name="Akshay Paliwal"

--- a/src/components/ZAvatar/ZAvatar.vue
+++ b/src/components/ZAvatar/ZAvatar.vue
@@ -33,6 +33,7 @@ const SIZES = {
   xs: { classes: 'leading-none h-4 w-4 text-xxs', text: 'xs' },
   sm: { classes: 'leading-none h-6 w-6 text-xs', text: 'sm' },
   md: { classes: 'leading-none h-8 w-8 text-sm', text: 'md' },
+  base: { classes: 'leading-none h-9 w-9 text-base', text: 'md' },
   lg: { classes: 'leading-none h-12 w-12 text-lg', text: 'lg' },
   xl: { classes: 'leading-none h-16 w-16 text-2xl', text: 'xl' }
 }

--- a/src/components/ZAvatar/ZAvatar.vue
+++ b/src/components/ZAvatar/ZAvatar.vue
@@ -33,7 +33,7 @@ const SIZES = {
   xs: { classes: 'leading-none h-4 w-4 text-xxs', text: 'xs' },
   sm: { classes: 'leading-none h-6 w-6 text-xs', text: 'sm' },
   md: { classes: 'leading-none h-8 w-8 text-sm', text: 'md' },
-  base: { classes: 'leading-none h-9 w-9 text-base', text: 'md' },
+  base: { classes: 'leading-none h-9 w-9 text-base', text: 'base' },
   lg: { classes: 'leading-none h-12 w-12 text-lg', text: 'lg' },
   xl: { classes: 'leading-none h-16 w-16 text-2xl', text: 'xl' }
 }


### PR DESCRIPTION
Adds a new avatar `base` size variant, with 36px height and width. This is required for the new workspaces tab in User settings

![Screenshot 2022-12-22 at 3 04 42 PM](https://user-images.githubusercontent.com/80349145/209104269-534a6a7e-2803-4436-ba90-212e742d3fee.png)
