### PR TITLE
fix: handle non-square images in ZAvatar [PDE-1366]

### DIFF
--- a/src/components/ZAvatar/ZAvatar.stories.ts
+++ b/src/components/ZAvatar/ZAvatar.stories.ts
@@ -195,3 +195,19 @@ export const WithSizes = (): Component => ({
     </div>
     `
 })
+
+export const WithRectangularImages = (): Component => ({
+  components: { ZAvatar },
+  template: `<div class='padded-container'>
+      <z-avatar
+        image="https://picsum.photos/id/237/200/400"
+        user-name="Doggy McDogFace"
+        size="xl"
+      ></z-avatar>
+      <z-avatar
+        image="https://picsum.photos/id/237/400/200"
+        user-name="Doggy McDogFace"
+        size="xl"
+      ></z-avatar>
+    </div>`
+})

--- a/src/components/ZAvatar/ZAvatar.vue
+++ b/src/components/ZAvatar/ZAvatar.vue
@@ -11,7 +11,7 @@
         v-if="this.image"
         :src="image"
         :alt="userName"
-        class="rounded-full"
+        class="rounded-full object-cover"
         :class="[`${SIZES[getSize].classes}`]"
         @error.once="setFallbackImage"
       />

--- a/tests/unit/__snapshots__/ZAvatar.spec.ts.snap
+++ b/tests/unit/__snapshots__/ZAvatar.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`Avatar component renders an avatar when the component is mounted 1`] = 
 `;
 
 exports[`Avatar component renders avatar correctly, when image is given 1`] = `
-<a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://example.com/some.jpg" alt="John Doe" class="rounded-full leading-none h-8 w-8 text-sm">
+<a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://example.com/some.jpg" alt="John Doe" class="rounded-full object-cover leading-none h-8 w-8 text-sm">
   <!---->
 </a>
 `;
@@ -41,7 +41,7 @@ exports[`Avatar component renders avatar correctly, when size is given 1`] = `
 exports[`Avatar component renders avatar with skeleton gradient background when loading is true 1`] = `<a class="inline-block rounded-full bg-ink-300 p-0.5"><span class="flex items-center justify-center text-center rounded-full bg-gradient-skeleton text-vanilla-300 leading-none h-8 w-8 text-sm"></span></a>`;
 
 exports[`Avatar component renders fallback image 1`] = `
-<a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://example.com/some.jpg" alt="John Doe" class="rounded-full leading-none h-8 w-8 text-sm">
+<a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://example.com/some.jpg" alt="John Doe" class="rounded-full object-cover leading-none h-8 w-8 text-sm">
   <!---->
 </a>
 `;

--- a/tests/unit/__snapshots__/ZTimeline.spec.ts.snap
+++ b/tests/unit/__snapshots__/ZTimeline.spec.ts.snap
@@ -27,7 +27,7 @@ exports[`ZTimeline renders a timeline component with custom border width 1`] = `
 <div class="timeline flex flex-col gap-y-2">
   <div class="relative flex timeline__item gap-x-2 h-32">
     <div class="flex flex-col items-center justify-center gap-y-2">
-      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
+      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full object-cover leading-none h-6 w-6 text-xs">
           <!---->
         </a></div> <span class="h-full border-l rounded-sm left-4 border-ink-100"></span>
     </div>
@@ -38,7 +38,7 @@ exports[`ZTimeline renders a timeline component with custom border width 1`] = `
   </div>
   <div class="relative flex timeline__item gap-x-2 h-32">
     <div class="flex flex-col items-center justify-center gap-y-2">
-      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
+      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full object-cover leading-none h-6 w-6 text-xs">
           <!---->
         </a></div> <span class="h-full border-l rounded-sm left-4 border-ink-100"></span>
     </div>
@@ -54,7 +54,7 @@ exports[`ZTimeline renders a timeline component with custom icon 1`] = `
 <div class="timeline flex flex-col gap-y-2">
   <div class="relative flex timeline__item gap-x-2 h-32">
     <div class="flex flex-col items-center justify-center gap-y-2">
-      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
+      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full object-cover leading-none h-6 w-6 text-xs">
           <!---->
         </a></div> <span class="h-full border-l rounded-sm left-4 border-ink-100 border-2"></span>
     </div>
@@ -65,7 +65,7 @@ exports[`ZTimeline renders a timeline component with custom icon 1`] = `
   </div>
   <div class="relative flex timeline__item gap-x-2 h-32">
     <div class="flex flex-col items-center justify-center gap-y-2">
-      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full leading-none h-6 w-6 text-xs">
+      <div class="flex items-center justify-center w-6 h-6"><a class="inline-block rounded-full bg-ink-300 p-0.5"><img src="https://randomuser.me/api/portraits/women/24.jpg" alt="Akshay Paliwal" class="rounded-full object-cover leading-none h-6 w-6 text-xs">
           <!---->
         </a></div> <span class="h-full border-l rounded-sm left-4 border-ink-100 border-2"></span>
     </div>


### PR DESCRIPTION
## Description

This PR aims to improve the way ZAvatar handles images that are not in a 1:1 aspect ratio. Currently the Images are squashed to fit the container:

![Screenshot 2023-01-12 at 12 23 25 PM](https://user-images.githubusercontent.com/80349145/211999441-9ea59d62-a9cd-4065-846c-9e909e5e6c95.png)

Using `object-fit: cover` allows us to handle these cases more gracefully:
![Screenshot 2023-01-12 at 12 23 36 PM](https://user-images.githubusercontent.com/80349145/211999599-a14729d2-dfdf-4eab-af5c-32a88c1cf229.png)

## Changes in this PR

* Added the `object-cover` utility to the ZAvatar `<img>`
* Added a story to showcase handling of non-square images
* Updated snapshots
