### PR TITLE
add required versions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ module.exports = {
 1. Node: v14@latest
 2. yarn: v1
 
-### Local setup steps
+### Local setup instructions
 
 1. Clone the Repo using `git clone https://github.com/deepsourcelabs/zeal`
 2. Run `yarn` to install all dependencies

--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ module.exports = {
 }
 ```
 
-## Dev Setup
+## Dev setup
+
+### Required Versions
+
+1. Node: v14@latest
+2. yarn: v1
+
+### Local setup steps
 
 1. Clone the Repo using `git clone https://github.com/deepsourcelabs/zeal`
 2. Run `yarn` to install all dependencies


### PR DESCRIPTION
Context:
Setting up zeal requires Node v14@latest and Yarn v1, which were not mentioned in the README.

Changes:
1. Add Required versions section to Dev Setup
  1.1. Add Node version
  1.2 Add yarn version
2. Put setup instructions under Local setup instructions