### PR TITLE
feat(ZSelect): add `maxHeight` prop

### DIFF
--- a/src/components/ZSelect/ZSelect.stories.ts
+++ b/src/components/ZSelect/ZSelect.stories.ts
@@ -836,7 +836,5 @@ export const SelectWithCustomMaxHeight = () => ({
                 </z-select>
 </div>
         </div>`,
-  StyleSheet: {
-
-  }
+  StyleSheet: {}
 })

--- a/src/components/ZSelect/ZSelect.stories.ts
+++ b/src/components/ZSelect/ZSelect.stories.ts
@@ -800,3 +800,43 @@ export const TruncatedSelect = () => ({
               </div>
             </div>`
 })
+
+/**
+ * UI state representing Select component with custom max height
+ *
+ * @returns {ExtendedVue}
+ */
+export const SelectWithCustomMaxHeight = () => ({
+  components: { ZSelect, ZOption, ZIcon, ZToggle },
+  data() {
+    return {
+      value: '',
+      disabled: true,
+      options: [
+        { label: 'Below 50', value: 'BLW_50' },
+        { label: '50-99', value: 'BTW_50_99' },
+        { label: '100-249', value: 'BTW_100_249' },
+        { label: '250-499', value: 'BTW_250_499' },
+        { label: '500-999', value: 'BTW_500_999' },
+        { label: '1000-2499', value: 'BTW_1000_2499' },
+        { label: '2500-4999', value: 'BTW_2500_4999' },
+        { label: '5000+', value: 'ABV_5000' }
+      ]
+    }
+  },
+  template: `<div class='padded-container'>
+              <div class="select-container space-y-4">
+                <z-select v-model="value" max-height="max-h-72" placeholder="Select no. of developers">
+                    <z-option
+                        v-for="item in options"
+                        :key="item.value"
+                        :label="item.label"
+                        :value="item.value">
+                    </z-option>
+                </z-select>
+</div>
+        </div>`,
+  StyleSheet: {
+
+  }
+})

--- a/src/components/ZSelect/ZSelect.vue
+++ b/src/components/ZSelect/ZSelect.vue
@@ -119,7 +119,7 @@ export default Vue.extend({
     maxHeight: {
       type: String,
       default: 'max-h-64'
-    },
+    }
   },
 
   model: {

--- a/src/components/ZSelect/ZSelect.vue
+++ b/src/components/ZSelect/ZSelect.vue
@@ -44,8 +44,8 @@
     </div>
     <!-- prettier-ignore -->
     <div
-      class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md max-h-64 options shadow-black border-ink-100 text-vanilla-300 bg-ink-300"
-      :class="!open && 'hidden'"
+      class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md options shadow-black border-ink-100 text-vanilla-300 bg-ink-300"
+      :class="[ { 'hidden' : !open  }, maxHeight  ]"
     >
       <slot></slot>
     </div>
@@ -115,7 +115,11 @@ export default Vue.extend({
     truncate: {
       default: false,
       type: Boolean
-    }
+    },
+    maxHeight: {
+      type: String,
+      default: 'max-h-64'
+    },
   },
 
   model: {

--- a/src/components/ZSelect/ZSelect.vue
+++ b/src/components/ZSelect/ZSelect.vue
@@ -118,7 +118,8 @@ export default Vue.extend({
     },
     maxHeight: {
       type: String,
-      default: 'max-h-64'
+      default: 'max-h-64',
+      validator: (value) => value.startsWith('max-h')
     }
   },
 

--- a/tests/unit/__snapshots__/ZSelect.spec.ts.snap
+++ b/tests/unit/__snapshots__/ZSelect.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`Select Component renders a select component with custom options templat
       Choose a framework
     </div> <span><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" fill="none" class="transition-all duration-300 transform z-icon w-4 h-4 z-icon--chevron-down text-vanilla-400 rotate-0"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
   </div>
-  <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md max-h-64 options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden">
+  <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden max-h-64">
     <div class="p-2 cursor-pointer z-option text-vanilla-300 hover:bg-ink-200 is-selected bg-ink-200 text-xs">
       <div class="flex items-center"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" fill="none" class="-mt-1 mr-2 z-icon w-4 h-4 z-icon--github text-vanilla-400">
           <path d="M11.9947 2.24707C9.62096 2.24717 7.32472 3.0919 5.51684 4.63011C3.70896 6.16832 2.5074 8.29963 2.12716 10.6427C1.74692 12.9858 2.21282 15.3877 3.44148 17.4187C4.67015 19.4497 6.5814 20.9772 8.83327 21.7279C9.3331 21.8154 9.52053 21.5155 9.52053 21.2531C9.52053 21.0157 9.50803 20.2284 9.50803 19.3912C6.99637 19.8536 6.34659 18.779 6.14666 18.2167C5.92481 17.6698 5.57313 17.1851 5.12201 16.8046C4.77213 16.6172 4.2723 16.1548 5.10951 16.1424C5.42918 16.1771 5.73579 16.2883 6.00334 16.4667C6.2709 16.645 6.49151 16.8852 6.64649 17.167C6.78322 17.4126 6.96706 17.6288 7.1875 17.8033C7.40793 17.9777 7.66062 18.1069 7.93109 18.1835C8.20155 18.2602 8.48448 18.2827 8.76365 18.2497C9.04282 18.2168 9.31276 18.1291 9.55798 17.9917C9.60126 17.4835 9.82775 17.0083 10.1953 16.6547C7.97104 16.4048 5.64683 15.5425 5.64683 11.7189C5.63279 10.7254 5.9994 9.76412 6.67148 9.03229C6.36587 8.16881 6.40163 7.22119 6.77145 6.38319C6.77145 6.38319 7.60863 6.12077 9.52051 7.40784C11.1562 6.95797 12.8831 6.95797 14.5188 7.40784C16.4306 6.10829 17.2679 6.38319 17.2679 6.38319C17.6378 7.22118 17.6735 8.16881 17.3678 9.03229C18.042 9.76287 18.4089 10.7249 18.3925 11.7189C18.3925 15.555 16.0558 16.4048 13.8315 16.6547C14.0701 16.8965 14.2539 17.1868 14.3703 17.5059C14.4867 17.825 14.5331 18.1654 14.5063 18.5041C14.5063 19.8411 14.4938 20.9157 14.4938 21.2531C14.4938 21.5156 14.6812 21.8279 15.1811 21.728C17.429 20.9711 19.3347 19.44 20.5582 17.408C21.7816 15.3759 22.2431 12.9752 21.8602 10.6345C21.4773 8.29366 20.275 6.16511 18.4679 4.62877C16.6608 3.09243 14.3666 2.2483 11.9947 2.24707Z" fill="#C0C1C3"></path>
@@ -31,7 +31,7 @@ exports[`Select Component renders a truncated select component 1`] = `
           Select an Option
         </div> <span><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" fill="none" class="transition-all duration-300 transform z-icon w-4 h-4 z-icon--chevron-down text-vanilla-400 rotate-0"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
       </div>
-      <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md max-h-64 options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden">
+      <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden max-h-64">
         <div class="p-2 cursor-pointer z-option text-vanilla-300 hover:bg-ink-200 px-4 overflow-x-scroll text-xs">Option 1</div>
         <div class="p-2 cursor-pointer z-option text-vanilla-300 hover:bg-ink-200 px-4 overflow-x-scroll text-xs">Adipisicing fugiat minim consectetur labore nulla quis sunt quis amet anim</div>
       </div>
@@ -47,7 +47,7 @@ exports[`Select Component renders the default select component 1`] = `
       Select an Option
     </div> <span><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" fill="none" class="transition-all duration-300 transform z-icon w-4 h-4 z-icon--chevron-down text-vanilla-400 rotate-0"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
   </div>
-  <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md max-h-64 options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden">
+  <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden max-h-64">
     <div class="p-2 cursor-pointer z-option text-vanilla-300 hover:bg-ink-200 text-xs">Option 1</div>
     <div class="p-2 cursor-pointer z-option text-vanilla-300 hover:bg-ink-200 text-xs">Option 2</div>
   </div>
@@ -61,7 +61,7 @@ exports[`Select Component renders the select component with clearables 1`] = `
       Choose a framework
     </div> <span><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" fill="none" class="transition-all duration-300 transform z-icon w-4 h-4 z-icon--chevron-down text-vanilla-400 rotate-0"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
   </div>
-  <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md max-h-64 options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden">
+  <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden max-h-64">
     <div class="p-2 cursor-pointer z-option text-vanilla-300 hover:bg-ink-200 text-xs">Option 1</div>
     <div class="p-2 cursor-pointer z-option text-vanilla-300 hover:bg-ink-200 text-xs">Option 2</div>
   </div>
@@ -75,7 +75,7 @@ exports[`Select Component renders the select with a custom placeholder 1`] = `
       Choose a framework
     </div> <span><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" fill="none" class="transition-all duration-300 transform z-icon w-4 h-4 z-icon--chevron-down text-vanilla-400 rotate-0"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
   </div>
-  <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md max-h-64 options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden">
+  <div class="absolute left-0 right-0 z-10 mt-1 overflow-y-auto transition-all duration-300 border border-solid rounded-md options shadow-black border-ink-100 text-vanilla-300 bg-ink-300 hidden max-h-64">
     <div class="p-2 cursor-pointer z-option text-vanilla-300 hover:bg-ink-200 text-xs">Option 1</div>
     <div class="p-2 cursor-pointer z-option text-vanilla-300 hover:bg-ink-200 text-xs">Option 2</div>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5727,9 +5727,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001165, caniuse-lite@^1.0.30001219:
-  version "1.0.30001406"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz"
-  integrity sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==
+  version "1.0.30001467"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001467.tgz"
+  integrity sha512-cEdN/5e+RPikvl9AHm4uuLXxeCNq8rFsQ+lPHTfe/OtypP3WwnVVbjn+6uBV7PaFL6xUFzTh+sSCOz1rKhcO+Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Adds a `maxHeight `prop to the `ZSelect` component that would allow specifying a custom max height based on the use case.
- Bumps `caniuse-lite`. [Ref](https://github.com/browserslist/update-db#why-you-need-to-call-it-regularly).